### PR TITLE
Add admin options for event text and count reset

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,1 +1,1 @@
-{"count":3}
+{ "count": 0, "eventText": "Event Text" }

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,7 @@
       <div id="count" class="count">0 people will be there.</div>
       <div id="status" class="status">You have not clicked the Be There Button.</div>
     </main>
+    <a id="admin-link" class="admin-link" href="#">admin</a>
     <script src="/script.js"></script>
   </body>
   </html>

--- a/public/script.js
+++ b/public/script.js
@@ -2,6 +2,8 @@
   const countEl = document.getElementById('count');
   const statusEl = document.getElementById('status');
   const buttonEl = document.getElementById('be-there');
+  const eventTextEl = document.getElementById('event-text');
+  const adminLink = document.getElementById('admin-link');
 
   const CLICK_KEY = 'be_there_clicked_v1';
 
@@ -24,11 +26,10 @@
     }
   }
 
-  async function fetchCount() {
-    const res = await fetch('/api/count', { cache: 'no-store' });
-    if (!res.ok) throw new Error('Failed to fetch count');
-    const data = await res.json();
-    return data.count ?? 0;
+  async function fetchState() {
+    const res = await fetch('/api/state', { cache: 'no-store' });
+    if (!res.ok) throw new Error('Failed to fetch state');
+    return res.json();
   }
 
   async function incrementCount() {
@@ -40,11 +41,12 @@
 
   async function init() {
     try {
-      const [count, clicked] = await Promise.all([
-        fetchCount(),
+      const [{ count, eventText }, clicked] = await Promise.all([
+        fetchState(),
         Promise.resolve(localStorage.getItem(CLICK_KEY) === 'true')
       ]);
       updateCountText(count);
+      eventTextEl.textContent = eventText;
       setStatusClicked(clicked);
     } catch (err) {
       updateCountText(0);
@@ -62,6 +64,31 @@
       setStatusClicked(true);
     } catch (err) {
       statusEl.textContent = 'Error submitting. Please try again.';
+    }
+  });
+
+  adminLink.addEventListener('click', async (e) => {
+    e.preventDefault();
+    const password = prompt('Enter admin password:');
+    if (password !== 'admin') return;
+    const newText = prompt('Event Text:', eventTextEl.textContent);
+    const reset = confirm('Reset count?');
+    try {
+      const res = await fetch('/api/admin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password, eventText: newText, resetCount: reset })
+      });
+      if (!res.ok) throw new Error('Failed');
+      const data = await res.json();
+      updateCountText(data.count ?? 0);
+      eventTextEl.textContent = data.eventText ?? '';
+      if (reset) {
+        localStorage.removeItem(CLICK_KEY);
+        setStatusClicked(false);
+      }
+    } catch (_err) {
+      alert('Admin action failed');
     }
   });
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -54,4 +54,16 @@ body {
 .count { font-size: 18px; }
 .status { font-size: 16px; color: var(--muted); max-width: 560px; }
 
+.admin-link {
+  position: fixed;
+  bottom: 8px;
+  right: 8px;
+  font-size: 12px;
+  color: var(--muted);
+  text-decoration: none;
+  opacity: 0.5;
+}
+
+.admin-link:hover { opacity: 0.8; }
+
 


### PR DESCRIPTION
## Summary
- Add password-protected admin link to change event text and optionally reset click count
- Expose backend state and admin endpoints; persist event text alongside count
- Style subtle admin link

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node server.js` & `curl -s http://localhost:3000/api/state`
- `curl -s -X POST http://localhost:3000/api/admin -H 'Content-Type: application/json' -d '{"password":"wrong"}' -w '\n%{http_code}\n'`
- `curl -s -X POST http://localhost:3000/api/admin -H 'Content-Type: application/json' -d '{"password":"admin","eventText":"New Event","resetCount":true}' -w '\n%{http_code}\n'`
- `curl -s http://localhost:3000/api/state && echo`


------
https://chatgpt.com/codex/tasks/task_e_68ab32f624b08325bdabc1f43c26b615