### PR TITLE
Reset user click status when admin resets count

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,1 +1,1 @@
-{ "count": 0, "eventText": "Event Text" }
+{ "count": 0, "eventText": "Event Text", "eventId": "0" }


### PR DESCRIPTION
## Summary
- Track a unique eventId in stored data and cookies
- Regenerate eventId whenever the admin resets the count, invalidating old click cookies

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab7369e5a08325aae4a13f4f6a2d75