### PR TITLE
Ensure count label matches spec and load state instantly

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -10,8 +10,7 @@
 
   function updateCountText(n) {
     currentCount = n;
-    const people = n === 1 ? 'person' : 'people';
-    countEl.textContent = `${n} ${people} will be there.`;
+    countEl.textContent = `${n} people will be there.`;
   }
 
   function setStatusClicked(clicked) {
@@ -40,7 +39,11 @@
 
   async function init() {
     try {
-      const { count, eventText, clicked } = await fetchState();
+      let state = window.__INITIAL_STATE__;
+      if (!state) {
+        state = await fetchState();
+      }
+      const { count, eventText, clicked } = state;
       updateCountText(count);
       eventTextEl.textContent = eventText;
       setStatusClicked(clicked);


### PR DESCRIPTION
## Summary
- Align count display with spec by always using "people" regardless of count
- Server-side render current count and event text so page loads with accurate state
- Use injected initial state on the client to avoid delayed updates

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab7584e994832587f2b4ad695cd44f