### PR TITLE
Track attendees by IP

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,1 +1,1 @@
-{ "count": 0, "eventText": "Event Text", "eventId": "0" }
+{ "count": 0, "eventText": "Event Text", "eventId": "0", "ips": [] }

--- a/public/script.js
+++ b/public/script.js
@@ -5,7 +5,6 @@
   const eventTextEl = document.getElementById('event-text');
   const adminLink = document.getElementById('admin-link');
 
-  const CLICK_COOKIE = 'be-there-clicked';
   let currentCount = 0;
 
   function updateCountText(n) {
@@ -89,7 +88,6 @@
       updateCountText(data.count ?? 0);
       eventTextEl.textContent = data.eventText ?? '';
       if (reset) {
-        document.cookie = `${CLICK_COOKIE}=; Max-Age=0; Path=/`;
         setStatusClicked(false);
       }
     } catch (_err) {


### PR DESCRIPTION
## Summary
- maintain a persistent list of visitor IPs and use it to track Be There button clicks
- base "clicked" status solely on whether the visitor's IP is in that list
- remove cookie-based tracking from client script

## Testing
- `npm test` (fails: Missing script: "test")
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_68ab793f106c83258afc07f41fa76634