### PR TITLE
Improve button styling, singular count text, and admin UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,11 +10,28 @@
     <main class="container">
       <h1 class="title">The Be There Button</h1>
       <div id="event-text" class="event-text">Event Text</div>
-      <button id="be-there" class="be-there" aria-label="Be There"></button>
+      <button id="be-there" class="be-there" aria-label="Be There">Be There</button>
       <div id="count" class="count">0 people will be there.</div>
       <div id="status" class="status">You have not clicked the Be There Button.</div>
     </main>
     <a id="admin-link" class="admin-link" href="#">admin</a>
+    <dialog id="admin-dialog" class="admin-dialog">
+      <form id="admin-form" method="dialog">
+        <label> Password
+          <input type="password" id="admin-password" required />
+        </label>
+        <label> Event Text
+          <input type="text" id="admin-event-text" />
+        </label>
+        <label class="reset">
+          <input type="checkbox" id="admin-reset" /> Reset count
+        </label>
+        <menu>
+          <button type="button" id="admin-cancel">Cancel</button>
+          <button type="submit" id="admin-submit">Save</button>
+        </menu>
+      </form>
+    </dialog>
     <script src="/script.js"></script>
   </body>
   </html>

--- a/public/script.js
+++ b/public/script.js
@@ -4,12 +4,19 @@
   const buttonEl = document.getElementById('be-there');
   const eventTextEl = document.getElementById('event-text');
   const adminLink = document.getElementById('admin-link');
+  const adminDialog = document.getElementById('admin-dialog');
+  const adminForm = document.getElementById('admin-form');
+  const adminPasswordInput = document.getElementById('admin-password');
+  const adminEventInput = document.getElementById('admin-event-text');
+  const adminResetInput = document.getElementById('admin-reset');
+  const adminCancelBtn = document.getElementById('admin-cancel');
 
   let currentCount = 0;
 
   function updateCountText(n) {
     currentCount = n;
-    countEl.textContent = `${n} people will be there.`;
+    const label = n === 1 ? 'person' : 'people';
+    countEl.textContent = `${n} ${label} will be there.`;
   }
 
   function setStatusClicked(clicked) {
@@ -67,12 +74,24 @@
     }
   });
 
-  adminLink.addEventListener('click', async (e) => {
+  adminLink.addEventListener('click', (e) => {
     e.preventDefault();
-    const password = prompt('Enter admin password:');
+    adminPasswordInput.value = '';
+    adminEventInput.value = eventTextEl.textContent;
+    adminResetInput.checked = false;
+    adminDialog.showModal();
+  });
+
+  adminCancelBtn.addEventListener('click', () => {
+    adminDialog.close();
+  });
+
+  adminForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const password = adminPasswordInput.value;
     if (!password) return;
-    const newText = prompt('Event Text:', eventTextEl.textContent);
-    const reset = confirm('Reset count?');
+    const newText = adminEventInput.value;
+    const reset = adminResetInput.checked;
     try {
       const res = await fetch('/api/admin', {
         method: 'POST',
@@ -90,6 +109,7 @@
       if (reset) {
         setStatusClicked(false);
       }
+      adminDialog.close();
     } catch (_err) {
       alert('Admin action failed');
     }

--- a/public/styles.css
+++ b/public/styles.css
@@ -36,12 +36,14 @@ body {
 .event-text { color: var(--muted); font-size: 18px; }
 
 .be-there {
-  width: 200px;
-  height: 200px;
-  border-radius: 50%;
+  padding: 24px 48px;
+  border-radius: 40px;
   border: none;
-  background: radial-gradient(circle at 30% 30%, #ffffffaa, #38bdf8 20%, var(--accent) 60%, var(--accent-dark) 100%);
-  box-shadow: 0 20px 40px rgba(34, 211, 238, 0.35), inset 0 8px 16px rgba(255,255,255,0.25), inset 0 -10px 20px rgba(0,0,0,0.25);
+  background: linear-gradient(180deg, #38bdf8 0%, var(--accent-dark) 100%);
+  color: var(--bg);
+  font-size: 24px;
+  font-weight: 700;
+  box-shadow: 0 8px 16px rgba(34, 211, 238, 0.35), inset 0 2px 4px rgba(255,255,255,0.3), inset 0 -4px 6px rgba(0,0,0,0.2);
   cursor: pointer;
   transition: transform 120ms ease, box-shadow 120ms ease, filter 120ms ease;
 }
@@ -49,7 +51,7 @@ body {
 .be-there:hover { filter: saturate(1.1); }
 .be-there:active {
   transform: translateY(2px) scale(0.98);
-  box-shadow: 0 14px 28px rgba(34, 211, 238, 0.25), inset 0 4px 8px rgba(255,255,255,0.15), inset 0 -6px 12px rgba(0,0,0,0.3);
+  box-shadow: 0 4px 8px rgba(34, 211, 238, 0.25), inset 0 2px 4px rgba(255,255,255,0.2), inset 0 -4px 8px rgba(0,0,0,0.3);
 }
 
 .count { font-size: 18px; }
@@ -66,5 +68,63 @@ body {
 }
 
 .admin-link:hover { opacity: 0.8; }
+
+.admin-dialog {
+  border: none;
+  border-radius: 8px;
+  padding: 20px;
+  background: var(--bg);
+  color: var(--fg);
+  width: 280px;
+}
+
+.admin-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.admin-dialog form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.admin-dialog label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  text-align: left;
+  gap: 4px;
+}
+
+.admin-dialog input[type="text"],
+.admin-dialog input[type="password"] {
+  padding: 6px;
+  border: 1px solid var(--muted);
+  border-radius: 4px;
+}
+
+.admin-dialog menu {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 8px;
+}
+
+.admin-dialog button {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.admin-dialog #admin-submit {
+  background: var(--accent);
+  color: var(--bg);
+}
+
+.admin-dialog #admin-cancel {
+  background: var(--muted);
+  color: var(--bg);
+}
 
 

--- a/server.js
+++ b/server.js
@@ -145,7 +145,7 @@ function serveStatic(req, res) {
       const stateScript = `<script>window.__INITIAL_STATE__=${JSON.stringify({ count: data.count, eventText: data.eventText, clicked })};</script>`;
       const rendered = html
         .replace('Event Text', escapeHtml(data.eventText))
-        .replace('0 people will be there.', `${data.count} people will be there.`)
+        .replace('0 people will be there.', `${data.count} ${data.count === 1 ? 'person' : 'people'} will be there.`)
         .replace('You have not clicked the Be There Button.', statusText)
         .replace('<script src="/script.js"></script>', `${stateScript}<script src="/script.js"></script>`);
       res.writeHead(200, { 'Content-Type': 'text/html', 'Cache-Control': 'no-store' });


### PR DESCRIPTION
## Summary
- Restyle Be There button into a large rounded rectangle with label text
- Show "person" when only one user will be there
- Replace prompt-based admin flow with a styled modal dialog

## Testing
- `npm start`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab7b3887148325aa40cb2e328f7d4b