### PR TITLE
Handle aborted admin requests gracefully

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -110,7 +110,9 @@
         setStatusClicked(false);
       }
       adminDialog.close();
-    } catch (_err) {
+    } catch (err) {
+      // Ignore aborted requests (e.g., page refresh) but surface other errors
+      if (err && err.name === 'AbortError') return;
       alert('Admin action failed');
     }
   });


### PR DESCRIPTION
## Summary
- Ignore `AbortError` when submitting admin actions so page refreshes don't trigger a spurious "Admin action failed" alert

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7d3e3a308325bc8c93f540365429