### PR TITLE
Restyle button and tidy admin reset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>The Be There Button</title>
+    <title>Official Cornell Math Department Be There Button</title>
     <link rel="stylesheet" href="/styles.css">
   </head>
   <body>
     <main class="container">
-      <h1 class="title">The Be There Button</h1>
+      <h1 class="title">Official Cornell Math Department Be There Button</h1>
       <div id="event-text" class="event-text">Event Text</div>
-      <button id="be-there" class="be-there" aria-label="Be There">Be There</button>
+      <button id="be-there" class="be-there" aria-label="Be There"></button>
       <div id="count" class="count">0 people will be there.</div>
       <div id="status" class="status">You have not clicked the Be There Button.</div>
     </main>

--- a/public/styles.css
+++ b/public/styles.css
@@ -36,22 +36,22 @@ body {
 .event-text { color: var(--muted); font-size: 18px; }
 
 .be-there {
-  padding: 24px 48px;
-  border-radius: 40px;
+  width: 160px;
+  height: 160px;
+  padding: 0;
+  border-radius: 50%;
   border: none;
-  background: linear-gradient(180deg, #38bdf8 0%, var(--accent-dark) 100%);
-  color: var(--bg);
-  font-size: 24px;
-  font-weight: 700;
-  box-shadow: 0 8px 16px rgba(34, 211, 238, 0.35), inset 0 2px 4px rgba(255,255,255,0.3), inset 0 -4px 6px rgba(0,0,0,0.2);
+  background: radial-gradient(circle at 30% 30%, #f87171 0%, #b91c1c 100%);
+  font-size: 0;
+  box-shadow: 0 8px 16px rgba(239, 68, 68, 0.35), inset 0 4px 6px rgba(255,255,255,0.3), inset 0 -6px 8px rgba(0,0,0,0.25);
   cursor: pointer;
   transition: transform 120ms ease, box-shadow 120ms ease, filter 120ms ease;
 }
 .be-there:disabled { cursor: pointer; }
-.be-there:hover { filter: saturate(1.1); }
+.be-there:hover { filter: brightness(1.05); }
 .be-there:active {
   transform: translateY(2px) scale(0.98);
-  box-shadow: 0 4px 8px rgba(34, 211, 238, 0.25), inset 0 2px 4px rgba(255,255,255,0.2), inset 0 -4px 8px rgba(0,0,0,0.3);
+  box-shadow: 0 4px 8px rgba(239, 68, 68, 0.25), inset 0 2px 4px rgba(255,255,255,0.2), inset 0 -4px 8px rgba(0,0,0,0.3);
 }
 
 .count { font-size: 18px; }
@@ -94,6 +94,12 @@ body {
   font-size: 14px;
   text-align: left;
   gap: 4px;
+}
+
+.admin-dialog label.reset {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
 }
 
 .admin-dialog input[type="text"],


### PR DESCRIPTION
## Summary
- Redesign be-there button as large red circle with no text label
- Update page title to "Official Cornell Math Department Be There Button"
- Align admin dialog reset checkbox with its label

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab817a39d88325b6d890de5d1ce7cf