### PR TITLE
Enable multiline event text in admin dialog

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
           <input type="password" id="admin-password" required />
         </label>
         <label> Event Text
-          <input type="text" id="admin-event-text" />
+          <textarea id="admin-event-text" rows="3"></textarea>
         </label>
         <label class="reset">
           <input type="checkbox" id="admin-reset" /> Reset count

--- a/public/styles.css
+++ b/public/styles.css
@@ -33,7 +33,11 @@ body {
   letter-spacing: 0.4px;
 }
 
-.event-text { color: var(--muted); font-size: 18px; }
+.event-text {
+  color: var(--muted);
+  font-size: 18px;
+  white-space: pre-line;
+}
 
 .be-there {
   width: 160px;
@@ -103,10 +107,16 @@ body {
 }
 
 .admin-dialog input[type="text"],
-.admin-dialog input[type="password"] {
+.admin-dialog input[type="password"],
+.admin-dialog textarea {
   padding: 6px;
   border: 1px solid var(--muted);
   border-radius: 4px;
+}
+
+.admin-dialog textarea {
+  min-height: 80px;
+  resize: vertical;
 }
 
 .admin-dialog menu {


### PR DESCRIPTION
## Summary
- Replace single-line event text input with a textarea so admins can enter multiple lines
- Preserve line breaks when displaying event text and style textarea for a larger editable area

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adae1299f4832597d6260cc23f4241